### PR TITLE
Allow one active return request per item

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This fork makes the following changes:
 - remove the need for admin to authorize a return/exchange request
 - add email confirmation when RMA is filed
 - remove return request list from order details page
+- only allow a return request to be file when there is no existing return authorization on the item (or when all existing ones are canceled)
 
 Installation
 ------------

--- a/app/models/spree/inventory_unit_decorator.rb
+++ b/app/models/spree/inventory_unit_decorator.rb
@@ -1,0 +1,8 @@
+module Spree
+  InventoryUnit.class_eval do
+    def exists_active_return_authorization?
+      # any existing return authorization that's not canceled means active
+      return_items.map(&:return_authorization).map(&:canceled?).include?(false)
+    end
+  end
+end

--- a/app/views/spree/orders/return_authorizations/_form.html.erb
+++ b/app/views/spree/orders/return_authorizations/_form.html.erb
@@ -18,7 +18,7 @@
       <%= f.fields_for :return_items, @form_return_items do |item_fields| %>
         <% return_item = item_fields.object %>
         <% inventory_unit = return_item.inventory_unit %>
-        <% editable = inventory_unit.shipped? && allow_return_item_changes && return_item.reimbursement.nil? %>
+        <% editable = inventory_unit.shipped? && !inventory_unit.exists_active_return_authorization? && allow_return_item_changes && return_item.reimbursement.nil?%>
         <tr>
           <td class="align-center" class="inventory-unit-checkbox">
             <% if editable %>


### PR DESCRIPTION
From UI stop a customer from filing a return request for any item
that already has an non-canceled return authorization.

This doesn't stop admin from creating multiple active return
authorizations per item.

@jsilland just some preparation work before we re write the ui for return interface. Most of the functionality we want is already there from the extension, just adding this bit of logic that we want.
