### PR TITLE
Revert "Remove admin authorization for RMAs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This extension adds a frontend interface to allow user to ask for items returns.
 
 This fork makes the following changes:
 - add exchange options to the frontend interface
-- remove the need for admin to authorize a return/exchange request
 - add email confirmation when RMA is filed
 - remove return request list from order details page
 - only allow a return request to be file when there is no existing return authorization on the item (or when all existing ones are canceled)

--- a/app/models/spree/return_authorization_decorator.rb
+++ b/app/models/spree/return_authorization_decorator.rb
@@ -1,4 +1,19 @@
 Spree::ReturnAuthorization.class_eval do
+  StateMachine::Machine.ignore_method_conflicts = true
+  state_machines.clear
+
+  state_machine initial: :pending do
+    before_transition to: :canceled, do: :cancel_return_items
+
+    event :authorize do
+      transition to: :authorized, from: :pending
+    end
+
+    event :cancel do
+      transition to: :canceled, from: [:pending, :authorized], if: lambda { |return_authorization| return_authorization.can_cancel_return_items? }
+    end
+  end
+
   after_commit :send_ra_confirmation_mail, on: :create
 
   private

--- a/spec/features/spree/admin/return_authorization_requests_spec.rb
+++ b/spec/features/spree/admin/return_authorization_requests_spec.rb
@@ -2,10 +2,12 @@ require 'spec_helper'
 
 describe 'admin/return_authorizations_requests', type: :feature do
   let(:admin)  { create(:admin_user) }
+  let(:pending_ra)  { create(:return_authorization, state: 'pending') }
   let(:authorized_ra)  { create(:return_authorization, state: 'authorized') }
   stub_authorization!
 
   before do
+    pending_ra
     authorized_ra
     admin
   end
@@ -13,6 +15,10 @@ describe 'admin/return_authorizations_requests', type: :feature do
   context 'index return authorization requests' do
     before do
       visit spree.admin_return_authorization_requests_path
+    end
+
+    it 'shows pending authorization requests' do
+      expect(page).to have_selector("tr#spree_return_authorization_#{pending_ra.id}")
     end
 
     it 'does not show authorized authorization requests' do

--- a/spec/features/spree/orders/return_authorizations_spec.rb
+++ b/spec/features/spree/orders/return_authorizations_spec.rb
@@ -19,9 +19,9 @@ describe 'orders/return_authorizations' do
         }.to change(Spree::ReturnAuthorization, :count).by(1)
       end
 
-      it 'has authorized state' do
+      it 'has pending state' do
         create_return_authorization_for(order)
-        expect(Spree::ReturnAuthorization.last.state).to eq('authorized')
+        expect(Spree::ReturnAuthorization.last.state).to eq('pending')
       end
     end
 

--- a/spec/models/spree/return_authorization_spec.rb
+++ b/spec/models/spree/return_authorization_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Spree::ReturnAuthorization, type: :model do
+  let(:return_authorization) { create(:return_authorization) }
+
+  it 'has state pending by default' do
+    expect(return_authorization.state).to eq('pending')
+  end
+end


### PR DESCRIPTION
This reverts commit 8a70aae47db2b1c8f4e3554cef5bfcdc7745a985.

It turns out we do need the return authorization to be in pending status
to begin with. Some of the returns will be approved automatically later.

@jsilland not sure if you cares about this, but this is step one of many to get rid of our fork.
